### PR TITLE
Improve batch verification API

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -8,19 +8,19 @@ import (
 	"filippo.io/edwards25519"
 )
 
-// BatchVerifier accumulates batch entries with `Add`, before performing batch verification with `Verify`.
+// BatchVerifier accumulates batch entries with Add, before performing batch verification with Verify.
 type BatchVerifier struct {
 	entries []entry
 }
 
-// item represents a batch entry with the public key, signature and scalar which the caller wants to verify
+// entry represents a batch entry with the public key, signature and scalar which the caller wants to verify
 type entry struct {
 	pubkey    ed25519.PublicKey
 	signature []byte
 	k         *edwards25519.Scalar
 }
 
-// NewBatchVerifier creates an empty `BatchVerifier`.
+// NewBatchVerifier creates an empty BatchVerifier.
 func NewBatchVerifier() BatchVerifier {
 	return BatchVerifier{
 		entries: []entry{},
@@ -62,12 +62,13 @@ func (v *BatchVerifier) Add(publicKey ed25519.PublicKey, message, sig []byte) {
 	v.entries = append(v.entries, e)
 }
 
-// Verify checks all entries in the current batch, returning `true` if
-// *all* entries are valid and `false` if *any one* entry is invalid.
+// Verify checks all entries in the current batch, returning true if all entries
+// are valid and false if any one entry is invalid.
 //
-// If a failure arises it is unknown which entry failed, the caller must verify each entry individually.
+// If a failure arises it is unknown which entry failed, the caller must verify
+// each entry individually.
 //
-// Calling `Verify` on an empty batch returns `false`.
+// Calling Verify on an empty batch returns false.
 func (v *BatchVerifier) Verify() bool {
 	vl := len(v.entries)
 	// Abort early on an empty batch, which probably indicates a bug

--- a/batch_test.go
+++ b/batch_test.go
@@ -17,6 +17,15 @@ func TestBatch(t *testing.T) {
 	}
 }
 
+func TestBatchFailsOnShortSig(t *testing.T) {
+	v := NewBatchVerifier()
+	pub, _, _ := ed25519.GenerateKey(nil)
+	v.Add(pub, []byte("message"), []byte{})
+	if v.Verify() {
+		t.Error("batch verification should fail due to short signature")
+	}
+}
+
 func TestBatchFailsOnCorruptKey(t *testing.T) {
 	v := NewBatchVerifier()
 	populateBatchVerifier(t, &v)

--- a/batch_test.go
+++ b/batch_test.go
@@ -12,31 +12,44 @@ func TestBatch(t *testing.T) {
 	v := NewBatchVerifier()
 	populateBatchVerifier(t, &v)
 
-	if !v.VerifyBatch() {
+	if !v.Verify() {
 		t.Error("failed batch verification")
 	}
+}
 
-	// corrput a key to check batch verification fails
+func TestBatchFailsOnCorruptKey(t *testing.T) {
+	v := NewBatchVerifier()
 	populateBatchVerifier(t, &v)
 	v.entries[1].pubkey[1] ^= 1
-	if v.VerifyBatch() {
+	if v.Verify() {
 		t.Error("batch verification should fail due to corrupt key")
 	}
+}
 
-	// corrput a signature to check batch verification fails
+func TestBatchFailsOnCorruptSignature(t *testing.T) {
+	v := NewBatchVerifier()
+
 	populateBatchVerifier(t, &v)
+	// corrupt the R value of one of the signatures
 	v.entries[4].signature[1] ^= 1
-	if v.VerifyBatch() {
-		t.Error("batch verification should fail due to corrupt key")
+	if v.Verify() {
+		t.Error("batch verification should fail due to corrupt signature")
 	}
 
 	populateBatchVerifier(t, &v)
 	// negate a scalar to check batch verification fails
 	v.entries[1].k.Negate(edwards25519.NewScalar())
-	if v.VerifyBatch() {
-		t.Error("batch verification should fail due to corrupt key")
+	if v.Verify() {
+		t.Error("batch verification should fail due to corrupt signature")
 	}
+}
 
+func TestEmptyBatchFails(t *testing.T) {
+	v := NewBatchVerifier()
+
+	if v.Verify() {
+		t.Error("batch verification should fail on an empty batch")
+	}
 }
 
 func BenchmarkVerifyBatch(b *testing.B) {
@@ -51,7 +64,7 @@ func BenchmarkVerifyBatch(b *testing.B) {
 			}
 			// NOTE: dividing by n so that metrics are per-signature
 			for i := 0; i < b.N/n; i++ {
-				if !v.VerifyBatch() {
+				if !v.Verify() {
 					b.Fatal("signature set failed batch verification")
 				}
 			}
@@ -61,6 +74,7 @@ func BenchmarkVerifyBatch(b *testing.B) {
 
 // populateBatchVerifier populates a verifier with multiple entries
 func populateBatchVerifier(t *testing.T, v *BatchVerifier) {
+	*v = NewBatchVerifier()
 	for i := 0; i <= 38; i++ {
 
 		pub, priv, _ := ed25519.GenerateKey(nil)
@@ -74,8 +88,6 @@ func populateBatchVerifier(t *testing.T, v *BatchVerifier) {
 
 		sig := ed25519.Sign(priv, msg)
 
-		if !v.Add(pub, sig, msg) {
-			t.Error("unable to add s k m")
-		}
+		v.Add(pub, msg, sig)
 	}
 }


### PR DESCRIPTION
Incorporates feedback from @FiloSottile.

- [x] fix the order of arguments in `BatchVerifier.Add` to match `Verify`;
- [x] made `Add` infallible, deferring failures to the batch verification;
- [x] rename `BatchVerifier.VerifyBatch` to `BatchVerifier.Verify`;
- [x] make `Verify` fail on an empty batch;
- [x] make `Verify` idempotent.

Closes #9