### PR TITLE
Add Support for Preallocating Entry Slice in Batch Verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ for [ZIP215] verification.
 
 Note that the ZIP215 rules ensure that individual and batch verification are
 guaranteed to give the same results, so unlike `ed25519.Verify`, `ed25519consensus.Verify` is
-compatible with batch verification (though this is not yet implemented by this
-library).
+compatible with batch verification.
 
 [ZIP215]: https://zips.z.cash/zip-0215

--- a/batch.go
+++ b/batch.go
@@ -27,6 +27,15 @@ func NewBatchVerifier() BatchVerifier {
 	}
 }
 
+// NewPreallocatedBatchVerifier creates a new BatchVerifier with
+// a preallocated capacity. If you know the size of the batch you plan
+// to create ahead of time, this can prevent needless memory copies.
+func NewPreallocatedBatchVerifier(size int) BatchVerifier {
+	return BatchVerifier{
+		entries: make([]entry, 0, size),
+	}
+}
+
 // Add adds a (public key, message, sig) triple to the current batch.
 func (v *BatchVerifier) Add(publicKey ed25519.PublicKey, message, sig []byte) {
 	// Compute the challenge scalar for this entry upfront, so that we don't

--- a/batch.go
+++ b/batch.go
@@ -8,16 +8,19 @@ import (
 	"filippo.io/edwards25519"
 )
 
-// BatchVerifier accumulates batch entries with Add, before performing batch verification with Verify.
+// BatchVerifier accumulates batch entries with Add, before performing batch
+// verification with Verify.
 type BatchVerifier struct {
 	entries []entry
 }
 
-// entry represents a batch entry with the public key, signature and scalar which the caller wants to verify
+// entry represents a batch entry with the public key, signature and scalar
+// which the caller wants to verify.
 type entry struct {
-	pubkey    ed25519.PublicKey
-	signature []byte
-	k         *edwards25519.Scalar
+	good      bool // good is true if the Add inputs were valid
+	pubkey    [ed25519.PublicKeySize]byte
+	signature [ed25519.SignatureSize]byte
+	digest    [64]byte
 }
 
 // NewBatchVerifier creates an empty BatchVerifier.
@@ -36,42 +39,30 @@ func NewPreallocatedBatchVerifier(size int) BatchVerifier {
 	}
 }
 
-// Add adds a (public key, message, sig) triple to the current batch.
+// Add adds a (public key, message, sig) triple to the current batch. It retains
+// no reference to the inputs.
 func (v *BatchVerifier) Add(publicKey ed25519.PublicKey, message, sig []byte) {
-	// Compute the challenge scalar for this entry upfront, so that we don't
-	// introduce a dependency on the lifetime of the message array. This doesn't
-	// matter so much for Go, which has garbage collection, but did matter for
-	// the Rust implementation this was ported from, but not keeping buffers
-	// alive for longer than they have to is nice to do anyways.
+	// Compute the challenge upfront to store it in the fixed-size entry
+	// structure that can get allocated on the caller stack and avoid heap
+	// allocations. Also, avoid holding any reference to the arguments.
+
+	v.entries = append(v.entries, entry{})
+	e := &v.entries[len(v.entries)-1]
+
+	if len(publicKey) != ed25519.PublicKeySize || len(sig) != ed25519.SignatureSize {
+		return
+	}
 
 	h := sha512.New()
-
-	// R_bytes is the first 32 bytes of the signature, but because the signature
-	// is passed as a variable-length array it could be too short. In that case
-	// we'll fail in Verify, so just avoid a panic here.
-	n := 32
-	if len(sig) < n {
-		n = len(sig)
-	}
-	h.Write(sig[:n])
-
+	h.Write(sig[:32])
 	h.Write(publicKey)
 	h.Write(message)
-	var digest [64]byte
-	h.Sum(digest[:0])
+	h.Sum(e.digest[:0])
 
-	k, err := new(edwards25519.Scalar).SetUniformBytes(digest[:])
-	if err != nil {
-		panic(err)
-	}
+	copy(e.pubkey[:], publicKey)
+	copy(e.signature[:], sig)
 
-	e := entry{
-		pubkey:    publicKey,
-		signature: sig,
-		k:         k,
-	}
-
-	v.entries = append(v.entries, e)
+	e.good = true
 }
 
 // Verify checks all entries in the current batch, returning true if all entries
@@ -106,7 +97,7 @@ func (v *BatchVerifier) Verify() bool {
 	}
 
 	Bcoeff := scalars[0]
-	Rcoeffs := scalars[1:][:int(vl)]
+	Rcoeffs := scalars[1 : 1+vl]
 	Acoeffs := scalars[1+vl:]
 
 	pvals := make([]edwards25519.Point, 1+vl+vl)
@@ -115,14 +106,13 @@ func (v *BatchVerifier) Verify() bool {
 		points[i] = &pvals[i]
 	}
 	B := points[0]
-	Rs := points[1:][:vl]
+	Rs := points[1 : 1+vl]
 	As := points[1+vl:]
 
+	buf := make([]byte, 32)
 	B.Set(edwards25519.NewGeneratorPoint())
 	for i, entry := range v.entries {
-		// Check that the signature is exactly 64 bytes upfront,
-		// so that we can slice it later without potential panics
-		if len(entry.signature) != 64 {
+		if !entry.good {
 			return false
 		}
 
@@ -130,14 +120,14 @@ func (v *BatchVerifier) Verify() bool {
 			return false
 		}
 
-		if _, err := As[i].SetBytes(entry.pubkey); err != nil {
+		if _, err := As[i].SetBytes(entry.pubkey[:]); err != nil {
 			return false
 		}
 
-		buf := make([]byte, 32)
-		rand.Read(buf[:16])
-		_, err := Rcoeffs[i].SetCanonicalBytes(buf)
-		if err != nil {
+		if _, err := rand.Read(buf[:16]); err != nil {
+			return false
+		}
+		if _, err := Rcoeffs[i].SetCanonicalBytes(buf); err != nil {
 			return false
 		}
 
@@ -147,7 +137,11 @@ func (v *BatchVerifier) Verify() bool {
 		}
 		Bcoeff.MultiplyAdd(Rcoeffs[i], s, Bcoeff)
 
-		Acoeffs[i].Multiply(Rcoeffs[i], entry.k)
+		k, err := new(edwards25519.Scalar).SetUniformBytes(entry.digest[:])
+		if err != nil {
+			return false
+		}
+		Acoeffs[i].Multiply(Rcoeffs[i], k)
 	}
 	Bcoeff.Negate(Bcoeff) // this term is subtracted in the summation
 

--- a/batch_test.go
+++ b/batch_test.go
@@ -4,8 +4,6 @@ import (
 	"crypto/ed25519"
 	"fmt"
 	"testing"
-
-	"filippo.io/edwards25519"
 )
 
 func TestBatch(t *testing.T) {
@@ -46,8 +44,7 @@ func TestBatchFailsOnCorruptSignature(t *testing.T) {
 	}
 
 	populateBatchVerifier(t, &v)
-	// negate a scalar to check batch verification fails
-	v.entries[1].k.Negate(edwards25519.NewScalar())
+	v.entries[1].digest[1] ^= 1
 	if v.Verify() {
 		t.Error("batch verification should fail due to corrupt signature")
 	}

--- a/batch_test.go
+++ b/batch_test.go
@@ -81,6 +81,54 @@ func BenchmarkVerifyBatch(b *testing.B) {
 	}
 }
 
+func BenchmarkCreateBatch(b *testing.B) {
+	for _, n := range []int{1, 8, 64, 1024, 4096, 16384} {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			b.StopTimer()
+			msg := []byte("CreateBatch")
+			pubs := make([][]byte, n)
+			sigs := make([][]byte, n)
+			for i := 0; i < n; i++ {
+				pub, priv, _ := ed25519.GenerateKey(nil)
+				pubs[i] = pub
+				sigs[i] = ed25519.Sign(priv, msg)
+			}
+			b.StartTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				v := NewBatchVerifier()
+				for j := 0; j < n; j++ {
+					v.Add(pubs[j], msg, sigs[j])
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCreatePreallocatedBatch(b *testing.B) {
+	for _, n := range []int{1, 8, 64, 1024, 4096, 16384} {
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			b.StopTimer()
+			msg := []byte("CreatePreallocatedBatch")
+			pubs := make([][]byte, n)
+			sigs := make([][]byte, n)
+			for i := 0; i < n; i++ {
+				pub, priv, _ := ed25519.GenerateKey(nil)
+				pubs[i] = pub
+				sigs[i] = ed25519.Sign(priv, msg)
+			}
+			b.StartTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				v := NewPreallocatedBatchVerifier(n)
+				for j := 0; j < n; j++ {
+					v.Add(pubs[j], msg, sigs[j])
+				}
+			}
+		})
+	}
+}
+
 // populateBatchVerifier populates a verifier with multiple entries
 func populateBatchVerifier(t *testing.T, v *BatchVerifier) {
 	*v = NewBatchVerifier()

--- a/batch_test.go
+++ b/batch_test.go
@@ -85,9 +85,11 @@ func BenchmarkCreateBatch(b *testing.B) {
 	for _, n := range []int{1, 8, 64, 1024, 4096, 16384} {
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.StopTimer()
-			msg := []byte("CreateBatch")
-			pubs := make([][]byte, n)
-			sigs := make([][]byte, n)
+			var (
+				msg  = []byte("CreateBatch")
+				pubs = make([][]byte, n)
+				sigs = make([][]byte, n)
+			)
 			for i := 0; i < n; i++ {
 				pub, priv, _ := ed25519.GenerateKey(nil)
 				pubs[i] = pub
@@ -109,9 +111,11 @@ func BenchmarkCreatePreallocatedBatch(b *testing.B) {
 	for _, n := range []int{1, 8, 64, 1024, 4096, 16384} {
 		b.Run(fmt.Sprint(n), func(b *testing.B) {
 			b.StopTimer()
-			msg := []byte("CreatePreallocatedBatch")
-			pubs := make([][]byte, n)
-			sigs := make([][]byte, n)
+			var (
+				msg  = []byte("CreatePreallocatedBatch")
+				pubs = make([][]byte, n)
+				sigs = make([][]byte, n)
+			)
 			for i := 0; i < n; i++ {
 				pub, priv, _ := ed25519.GenerateKey(nil)
 				pubs[i] = pub


### PR DESCRIPTION
Before:
```
goos: darwin
goarch: arm64
pkg: github.com/hdevalence/ed25519consensus
BenchmarkCreateBatch/1-12  	 5439469	       214.8 ns/op	      96 B/op	       2 allocs/op
BenchmarkCreateBatch/8-12  	  704911	      1714 ns/op	    1104 B/op	      12 allocs/op
BenchmarkCreateBatch/64-12 	   90453	     13074 ns/op	    9680 B/op	      71 allocs/op
BenchmarkCreateBatch/1024-12         	    5697	    204843 ns/op	  155089 B/op	    1035 allocs/op
BenchmarkCreateBatch/4096-12         	    1401	    859972 ns/op	  892369 B/op	    4111 allocs/op
BenchmarkCreateBatch/16384-12        	     316	   3727873 ns/op	 5094872 B/op	   16405 allocs/op
PASS
ok  	github.com/hdevalence/ed25519consensus	10.901s
```

After (**~71% reduction in bytes allocated, ~13% reduction in runtime on batch of 16384**):
```
goos: darwin
goarch: arm64
pkg: github.com/hdevalence/ed25519consensus
BenchmarkCreatePreallocatedBatch/1-12  	 5431094	       213.9 ns/op	      96 B/op	       2 allocs/op
BenchmarkCreatePreallocatedBatch/8-12  	  762730	      1585 ns/op	     704 B/op	       9 allocs/op
BenchmarkCreatePreallocatedBatch/64-12 	   95875	     12557 ns/op	    6144 B/op	      65 allocs/op
BenchmarkCreatePreallocatedBatch/1024-12         	    5967	    199347 ns/op	   90112 B/op	    1025 allocs/op
BenchmarkCreatePreallocatedBatch/4096-12         	    1501	    805202 ns/op	  360449 B/op	    4097 allocs/op
BenchmarkCreatePreallocatedBatch/16384-12        	     374	   3237073 ns/op	 1441795 B/op	   16385 allocs/op
PASS
ok  	github.com/hdevalence/ed25519consensus	10.878s
```